### PR TITLE
Fixed timer being off by 1 tick

### DIFF
--- a/src/main/java/net/minecraftforge/lex/cfd/CobbleGenTile.java
+++ b/src/main/java/net/minecraftforge/lex/cfd/CobbleGenTile.java
@@ -84,8 +84,8 @@ public class CobbleGenTile extends TileEntity implements ITickableTileEntity {
 
     @Override
     public void tick() {
-        if (getLevel() != null && getLevel().isClientSide) return;
-        if (timer-- <= 0) {
+        if (getLevel() == null || getLevel().isClientSide) return;
+        if (--timer <= 0) {
             count += config.count;
             this.timer = config.interval;
 
@@ -101,7 +101,7 @@ public class CobbleGenTile extends TileEntity implements ITickableTileEntity {
             push();
         }
 
-        if (configTimer-- <= 0) {
+        if (--configTimer <= 0) {
             config.update();
             configTimer = 200;
         }


### PR DESCRIPTION
Intent of this timer was to be "every x ticks", but the current version is always 1 extra because `if (timer-- <= 0)` compares first, then decrements the number.