### PR TITLE
Return correct stack count when getStackInSlot is called.

### DIFF
--- a/src/main/java/net/minecraftforge/lex/cfd/CobbleGenTile.java
+++ b/src/main/java/net/minecraftforge/lex/cfd/CobbleGenTile.java
@@ -172,6 +172,7 @@ public class CobbleGenTile extends TileEntity implements ITickableTileEntity {
 
         @Override
         public ItemStack getStackInSlot(int slot) {
+            stack.setCount(count);
             return stack;
         }
 


### PR DESCRIPTION
Calling getStackInSlot always return 0 cobblestone instead of the amount available for extraction, this pull request corrects that behaviour.